### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-red-contrib-postgres-listen",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Node-RED node to listen to pg_notify",
   "dependencies": {
-    "pg": "~7.4.1",
-    "node-red-contrib-postgres": "~0.6.1"
+    "pg": "^6.1.5",
+    "node-red-contrib-re-postgres": "~0.1.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As the node-red-contrib-postgres is deprecated due to compatibility issues with the new version of node-red this package has been replaced with node-red-contrib-re-postgres.